### PR TITLE
Make SETTINGSFILE lookup work on boot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ It is possible to run multiple instances, for example a Creative server and a Su
 
     ~~~
     /etc/default/minecraft-creative
-    /etc/default/minecraft-creative
+    /etc/default/minecraft-survival
     ~~~
 
 *   Set an alias for each server in `~/.bashrc`

--- a/minecraft
+++ b/minecraft
@@ -107,7 +107,7 @@ COMMENT
 ## Apply the settings file
 
 # define the location of the settings file from the name of this script
-SETTINGSFILE="/etc/default/$(basename $0)"
+SETTINGSFILE="/etc/default/$(basename $(readlink -f $0))"
 
 # check the file exists, and fail if not
 if [ ! -f "$SETTINGSFILE" ]


### PR DESCRIPTION
Have to follow symlinks to get the right basename as
it will be different in /etc/rc?.d and not match the
config file.
